### PR TITLE
Feat: add tax caculator executor

### DIFF
--- a/caculator.py
+++ b/caculator.py
@@ -1,0 +1,38 @@
+
+from lib.caculation_exec import TaxCaculator
+from lib.fetch_input import fetch_prod_name, fetch_prod_price, fetch_product_sum
+from lib.vali_input import caculate_tax, round_nr
+
+
+if __name__ == "__main__":
+
+    origin_price = 0.0
+    price_sum = 0.0
+    prod_list = []
+
+    running = True
+
+    executor = TaxCaculator()
+
+    while(running):
+        print("> ", end="")
+        input_str = input()
+        input_str = input_str.strip()
+
+        if not input_str:
+            break
+        elif len(input_str.split(" ")) < 3:
+            continue
+        else:
+            prod_list.append([fetch_product_sum(input_str), fetch_prod_name(input_str), round_nr(caculate_tax(input_str)[0])])
+            result = executor.tax_cacul_exec(input_str)
+            origin_price += result[0]
+            price_sum += round(result[1], 2)
+
+    for p in prod_list:
+        print("> {} {}: {}".format(p[0], p[1], p[2]))    
+        
+    print("> Sales Taxes: {}".format(round(price_sum - origin_price, 2)))
+    print("> Total: {}".format(round(price_sum, 2)))
+
+

--- a/lib/caculation_exec.py
+++ b/lib/caculation_exec.py
@@ -1,0 +1,18 @@
+from lib.fetch_input import fetch_product_sum, fetch_is_prod_imported, fetch_prod_price, fetch_prod_name
+from lib.vali_input import is_prod_tax_free, caculate_tax, round_nr
+
+class TaxCaculator:
+    '''
+    A class for tax caculation
+
+    Method
+    -----
+    tax_cacul_exec(str_input)
+        caculate the price after tax
+    '''
+
+    def tax_cacul_exec(str_input):
+        origin_price += fetch_prod_price(str_input)
+        price_after_tax = caculate_tax(str_input)
+
+        return [origin_price, round_nr(price_after_tax)]

--- a/tests/test_vali_input.py
+++ b/tests/test_vali_input.py
@@ -1,6 +1,7 @@
 import pytest
 
 from lib.vali_input import is_prod_tax_free, caculate_tax, round_nr
+from lib.fetch_input import fetch_prod_price
 
 #normal prod name
 @pytest.fixture
@@ -25,11 +26,35 @@ def prod_taxes():
 
     return prod_list
 
-#
+#data for testing nr rounding to 0.05
 @pytest.fixture
 def unrounded_nrs():
     return [[6.10, 6.10], [6.12, 6.15], [6.18, 6.18]]
 
+#prod with tax
+@pytest.fixture
+def prods():
+    prod_list = []
+    prod_list.append(
+        [
+        ["1 book at 12.49", "1 music CD at 14.99", "1 chocolate bar at 0.85"], 
+        29.83,
+        1.5
+        ])
+    prod_list.append(
+        [
+        ["1 imported box of chocolates at 10.00", "1 imported bottle of perfume at 47.50"], 
+        65.15,
+        7.65
+        ])
+    prod_list.append(
+        [
+        ["1 imported bottle of perfume at 27.99", "1 bottle of perfume at 18.99", "1 packet of headache pills at 9.75", "1 box of imported chocolates at 11.25"], 
+        74.68,
+        6.7
+        ])
+    
+    return prod_list
 
 class TestInputValidation:
 
@@ -48,5 +73,17 @@ class TestInputValidation:
         for nr in unrounded_nrs:
             assert round_nr(nr[0]) == nr[1]
         
+    def test_tax_cacul_and_round_nr(self, prods):
 
+        for p in prods:
+            origin_price = 0.0
+            price_sum = 0.0
+            
+            for item in p[0]:
+                origin_price += fetch_prod_price(item)
+                result = caculate_tax(item)
+                price_sum += round_nr(result[0])
+
+            assert round(price_sum, 2) == p[1]
+            assert round(price_sum - origin_price, 2) == p[2]
             

--- a/tests/test_vali_input.py
+++ b/tests/test_vali_input.py
@@ -2,6 +2,7 @@ import pytest
 
 from lib.vali_input import is_prod_tax_free, caculate_tax, round_nr
 from lib.fetch_input import fetch_prod_price
+from lib.caculation_exec import TaxCaculator
 
 #normal prod name
 @pytest.fixture
@@ -83,7 +84,16 @@ class TestInputValidation:
                 origin_price += fetch_prod_price(item)
                 result = caculate_tax(item)
                 price_sum += round_nr(result[0])
-
+                
             assert round(price_sum, 2) == p[1]
             assert round(price_sum - origin_price, 2) == p[2]
             
+    def test_excutor(self):
+        executor = TaxCaculator()
+        result = executor.tax_cacul_exec("1 book at 12.49")
+        assert result[0] == 12.49
+        assert result[1] == 12.49
+
+        result = executor.tax_cacul_exec("1 imported box of chocolates at 10.00")
+        assert result[0] == 10.0
+        assert result[1] == 10.5

--- a/tests/test_vali_input.py
+++ b/tests/test_vali_input.py
@@ -20,9 +20,8 @@ def prod_names():
 @pytest.fixture
 def prod_taxes():
     prod_list = []
-    prod_list.append(["1 book at 12.49", 12.49, 0.0])
     prod_list.append(["1 imported box of chocolates at 10.00", 10.5, 0.5])
-    prod_list.append(["1 imported bottle of perfume at 47.50", 54.65, 7.15 ])
+    prod_list.append(["1 imported bottle of perfume at 47.50", 54.63, 7.13])
 
     return prod_list
 
@@ -39,17 +38,15 @@ class TestInputValidation:
         for name in prod_names:
             assert is_prod_tax_free(name[0]) == name[1]
      
-    #def test_tax_caculation(self, prod_taxes):
-    #    for p in prod_taxes:
-    #        result = caculate_tax(p[0])
-    #        assert result[0] == p[1]
-    #        assert result[1] == p[2]
-    #
+    def test_tax_cacul(self, prod_taxes):
+        for p in prod_taxes:
+            result = caculate_tax(p[0])
+            assert result[0] == p[1]
+            assert result[1] == p[2]
     
     def test_round_nr(self, unrounded_nrs):
         for nr in unrounded_nrs:
             assert round_nr(nr[0]) == nr[1]
-        
         
 
             


### PR DESCRIPTION
## This PR did followings:
- fix tax caculation test case
- add test case for combing tax caculation and nr rounding
- add tax caculation executor
- add test for tax caculation executor
- add final executor app